### PR TITLE
feat: 0.0.2 Handle crate features, configurable PATH check, refactor user confirm to take the version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rspawn"
 description = "A crate to fetch latest from crates.io and update your binary"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/jgabaut/rspawn"

--- a/README.md
+++ b/README.md
@@ -3,3 +3,29 @@
 A crate to fetch latest version from crates.io and update your binary.
 
 Similar crates do similar things, but none had the specific mix I needed.
+
+## Usage
+
+  ```rust
+  use rspawn::relaunch_program;
+  use std::io;
+
+  fn main() {
+      let crate_name = "rspawn";
+
+      let custom_confirm = |version: &str| {
+          println!("A new version {} is available. Would you like to install it? (yes/n): ", version);
+
+          let mut response = String::new();
+          io::stdin().read_line(&mut response).unwrap();
+          response.trim().to_lowercase() == "yes"
+      };
+
+      #[allow(non_snake_case)]
+      let check_if_executed_from_PATH = false;
+
+      if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
+          eprintln!("Error: {}", e);
+      }
+  }
+  ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Similar crates do similar things, but none had the specific mix I needed.
       };
 
       #[allow(non_snake_case)]
-      let check_if_executed_from_PATH = false;
+      let check_if_executed_from_PATH = true; // Only ask for update when called from PATH
 
       if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
           eprintln!("Error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
     };
 
     #[allow(non_snake_case)]
-    let check_if_executed_from_PATH = false;
+    let check_if_executed_from_PATH = true;
 
     if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
         eprintln!("Error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,13 +12,21 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 use rspawn::relaunch_program;
+use std::io;
 
 fn main() {
     let crate_name = "rspawn";
 
-    let custom_confirm = |response: &str| response.trim().to_lowercase() == "yes";
+    let custom_confirm = |version: &str| {
+        println!("A new version {} is available. Would you like to install it? (yes/n): ", version);
 
-    let check_if_executed_from_PATH = true;
+        let mut response = String::new();
+        io::stdin().read_line(&mut response).unwrap();
+        response.trim().to_lowercase() == "yes"
+    };
+
+    #[allow(non_snake_case)]
+    let check_if_executed_from_PATH = false;
 
     if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
         eprintln!("Error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
     };
 
     #[allow(non_snake_case)]
-    let check_if_executed_from_PATH = true;
+    let check_if_executed_from_PATH = true; // Only ask for update when called from PATH
 
     if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
         eprintln!("Error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,9 @@ fn main() {
 
     let custom_confirm = |response: &str| response.trim().to_lowercase() == "yes";
 
-    if let Err(e) = relaunch_program(crate_name, Some(custom_confirm)) {
+    let check_if_executed_from_PATH = true;
+
+    if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
         eprintln!("Error: {}", e);
     }
 }


### PR DESCRIPTION
- Handle crate features for the install by having the user pass a `Option<Vec<String>>` to `relaunch_program()`
- Handle checking if program was called from `PATH` by having the user pass `check_if_executed_from_PATH: bool` to `relaunch_program()`
- Refactor user confirm: now expected to take the version, instead of a string response
- Refactor `default_user_confirm()`
  - Move the `io::stdin.read_line()` in here instead of having it in `relaunch_program()`
- Improve `is_executed_from_path()`