### PR TITLE
0.0.2 - Handle crate features, configurable PATH check, refactor user confirm to take the version

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,59 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @jgabaut
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+#*.js    @js-owner #This is an inline comment.
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+#*.go docs@example.com
+
+# Teams can be specified as code owners as well. Teams should
+# be identified in the format @org/team-name. Teams must have
+# explicit write access to the repository. In this example,
+# the octocats team in the octo-org organization owns all .txt files.
+#*.txt @octo-org/octocats
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+#/build/logs/ @doctocat
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+#docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+#apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository and any of its
+# subdirectories.
+#/docs/ @doctocat
+
+# In this example, any change inside the `/scripts` directory
+# will require approval from @doctocat or @octocat.
+#/scripts/ @doctocat @octocat
+
+# In this example, @octocat owns any file in a `/logs` directory such as
+# `/build/logs`, `/scripts/logs`, and `/deeply/nested/logs`. Any changes
+# in a `/logs` directory will require approval from @octocat.
+#**/logs @octocat
+
+# In this example, @octocat owns any file in the `/apps`
+# directory in the root of your repository except for the `/apps/github`
+# subdirectory, as its owners are left empty.
+#/apps/ @octocat
+#/apps/github

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rspawn"
 description = "A crate to fetch latest from crates.io and update your binary"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/jgabaut/rspawn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rspawn"
 description = "A crate to fetch latest from crates.io and update your binary"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/jgabaut/rspawn"

--- a/README.md
+++ b/README.md
@@ -3,3 +3,29 @@
 A crate to fetch latest version from crates.io and update your binary.
 
 Similar crates do similar things, but none had the specific mix I needed.
+
+## Usage
+
+  ```rust
+  use rspawn::relaunch_program;
+  use std::io;
+
+  fn main() {
+      let crate_name = "rspawn";
+
+      let custom_confirm = |version: &str| {
+          println!("A new version {} is available. Would you like to install it? (yes/n): ", version);
+
+          let mut response = String::new();
+          io::stdin().read_line(&mut response).unwrap();
+          response.trim().to_lowercase() == "yes"
+      };
+
+      #[allow(non_snake_case)]
+      let check_if_executed_from_PATH = false;
+
+      if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
+          eprintln!("Error: {}", e);
+      }
+  }
+  ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Similar crates do similar things, but none had the specific mix I needed.
       };
 
       #[allow(non_snake_case)]
-      let check_if_executed_from_PATH = false;
+      let check_if_executed_from_PATH = true; // Only ask for update when called from PATH
 
       if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
           eprintln!("Error: {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ fn create_lock_file(lock_file_path: &Path) -> io::Result<()> {
 fn get_latest_version_from_crates_io(crate_name: &str) -> Result<String> {
     let url = format!("https://crates.io/api/v1/crates/{}/versions", crate_name);
 
-    eprintln!("Fetching latest version from: {}", url); // Debug log
+    //eprintln!("Fetching latest version from: {}", url);
 
     // Create a client with a User-Agent header
     let client = reqwest::blocking::Client::new();
@@ -60,17 +60,17 @@ fn get_latest_version_from_crates_io(crate_name: &str) -> Result<String> {
         .context("Failed to fetch from crates.io")?;
 
     let status = response.status();
-    eprintln!("Response status: {}", status); // Debug log
+    //eprintln!("Response status: {}", status);
 
     if !status.is_success() {
         return Err(anyhow::anyhow!("Failed to fetch crate info: HTTP {}", status));
     }
 
     let body = response.text().context("Failed to read response body")?;
-    eprintln!("Response body: {}", body); // Debug log
+    //eprintln!("Response body: {}", body);
 
     let json: Value = serde_json::from_str(&body).context("Failed to parse JSON response")?;
-    eprintln!("Parsed JSON: {:?}", json); // Debug log
+    //eprintln!("Parsed JSON: {:?}", json);
 
     let latest_version = json["versions"]
         .as_array()

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
     };
 
     #[allow(non_snake_case)]
-    let check_if_executed_from_PATH = false;
+    let check_if_executed_from_PATH = true;
 
     if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
         eprintln!("Error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,13 +12,21 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 use rspawn::relaunch_program;
+use std::io;
 
 fn main() {
     let crate_name = "rspawn";
 
-    let custom_confirm = |response: &str| response.trim().to_lowercase() == "yes";
+    let custom_confirm = |version: &str| {
+        println!("A new version {} is available. Would you like to install it? (yes/n): ", version);
 
-    let check_if_executed_from_PATH = true;
+        let mut response = String::new();
+        io::stdin().read_line(&mut response).unwrap();
+        response.trim().to_lowercase() == "yes"
+    };
+
+    #[allow(non_snake_case)]
+    let check_if_executed_from_PATH = false;
 
     if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
         eprintln!("Error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
     };
 
     #[allow(non_snake_case)]
-    let check_if_executed_from_PATH = true;
+    let check_if_executed_from_PATH = true; // Only ask for update when called from PATH
 
     if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
         eprintln!("Error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,9 @@ fn main() {
 
     let custom_confirm = |response: &str| response.trim().to_lowercase() == "yes";
 
-    if let Err(e) = relaunch_program(crate_name, Some(custom_confirm)) {
+    let check_if_executed_from_PATH = true;
+
+    if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
         eprintln!("Error: {}", e);
     }
 }


### PR DESCRIPTION
- Handle crate features for the install by having the user pass a `Option<Vec<String>>` to `relaunch_program()`
- Handle checking if program was called from `PATH` by having the user pass `check_if_executed_from_PATH: bool` to `relaunch_program()`
- Refactor user confirm: now expected to take the version, instead of a string response
- Refactor `default_user_confirm()`
  - Move the `io::stdin.read_line()` in here instead of having it in `relaunch_program()`
- Improve `is_executed_from_path()`