### PR TITLE
feat: 0.0.3 RSpawn builder, current rspawn version in user agent, declare lib crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,12 @@ version = "0.0.3"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/jgabaut/rspawn"
+documentation = "https://docs.rs/rspawn"
 readme = "README.md"
+exclude = [
+    ".github/**",
+    "CODEOWNERS",
+]
 
 [lib]
 crate-type = ["lib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,15 @@ license = "GPL-3.0-only"
 repository = "https://github.com/jgabaut/rspawn"
 readme = "README.md"
 
+[lib]
+crate-type = ["lib"]
+
 [dependencies]
 anyhow = "1.0.94"
+log = "0.4.22"
 reqwest = { version = "0.12.9", features = ["blocking"] }
 serde_json = "1.0.133"
 uuid = { version = "1.11.0", features = ["v4"] }
+
+[dev-dependencies]
+env_logger = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rspawn"
 description = "A crate to fetch latest from crates.io and update your binary"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/jgabaut/rspawn"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Similar crates do similar things, but none had the specific mix I needed.
   use std::io;
 
   fn main() {
-      let crate_name = "rspawn";
 
       let custom_confirm = |version: &str| {
           println!("A new version {} is available. Would you like to install it? (yes/n): ", version);
@@ -27,7 +26,7 @@ Similar crates do similar things, but none had the specific mix I needed.
       #[allow(non_snake_case)]
       let check_if_executed_from_PATH = true; // Only ask for update when called from PATH
 
-      if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
+      if let Err(e) = relaunch_program(None, Some(custom_confirm), check_if_executed_from_PATH) {
           eprintln!("Error: {}", e);
       }
   }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Similar crates do similar things, but none had the specific mix I needed.
 
 ## Usage
 
+  Run example with `cargo run --example usage`.
+  See [examples/usage.rs](./examples/usage.rs):
+
   ```rust
   use rspawn::relaunch_program;
   use std::io;

--- a/examples/builder.rs
+++ b/examples/builder.rs
@@ -1,0 +1,45 @@
+//  SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Copyright (C) 2024  jgabaut
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3 of the License.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+use rspawn::RSpawnBuilder;
+use std::io;
+
+fn init_logger() {
+    use env_logger::Env;
+
+    // Set up the logger for the binary only
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+}
+
+fn main() {
+
+    // Initialize the logger
+    init_logger();
+
+    let custom_confirm = |version: &str| {
+        println!("A new version {} is available. Would you like to install it? (yes/n): ", version);
+
+        let mut response = String::new();
+        io::stdin().read_line(&mut response).unwrap();
+        response.trim().to_lowercase() == "yes"
+    };
+
+    #[allow(non_snake_case)]
+    let check_if_executed_from_PATH = false; // Only ask for update when called from PATH
+    if let Err(e) = RSpawnBuilder::new()
+        .check_if_executed_from_PATH(check_if_executed_from_PATH)
+        .user_confirm(custom_confirm)
+        .build_and_run() {
+        eprintln!("Error: {}", e);
+    }
+}

--- a/examples/builder.rs
+++ b/examples/builder.rs
@@ -39,7 +39,7 @@ fn main() {
     if let Err(e) = RSpawnBuilder::new()
         .check_if_executed_from_PATH(check_if_executed_from_PATH)
         .user_confirm(custom_confirm)
-        .build_and_run() {
+        .relaunch_program() {
         eprintln!("Error: {}", e);
     }
 }

--- a/examples/builder.rs
+++ b/examples/builder.rs
@@ -11,7 +11,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-use rspawn::RSpawnBuilder;
+use rspawn::RSpawn;
 use std::io;
 
 fn init_logger() {
@@ -36,7 +36,7 @@ fn main() {
 
     #[allow(non_snake_case)]
     let check_if_executed_from_PATH = false; // Only ask for update when called from PATH
-    if let Err(e) = RSpawnBuilder::new()
+    if let Err(e) = RSpawn::new()
         .check_if_executed_from_PATH(check_if_executed_from_PATH)
         .user_confirm(custom_confirm)
         .relaunch_program() {

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -14,8 +14,18 @@
 use rspawn::relaunch_program;
 use std::io;
 
+fn init_logger() {
+    use env_logger::Env;
+
+    // Set up the logger for the binary only
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+}
+
 fn main() {
     let crate_name = "rspawn";
+
+    // Initialize the logger
+    init_logger();
 
     let custom_confirm = |version: &str| {
         println!("A new version {} is available. Would you like to install it? (yes/n): ", version);
@@ -26,7 +36,7 @@ fn main() {
     };
 
     #[allow(non_snake_case)]
-    let check_if_executed_from_PATH = true; // Only ask for update when called from PATH
+    let check_if_executed_from_PATH = false; // Only ask for update when called from PATH
 
     if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
         eprintln!("Error: {}", e);

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -22,7 +22,6 @@ fn init_logger() {
 }
 
 fn main() {
-    let crate_name = "rspawn";
 
     // Initialize the logger
     init_logger();
@@ -38,7 +37,7 @@ fn main() {
     #[allow(non_snake_case)]
     let check_if_executed_from_PATH = false; // Only ask for update when called from PATH
 
-    if let Err(e) = relaunch_program(crate_name, None, Some(custom_confirm), check_if_executed_from_PATH) {
+    if let Err(e) = relaunch_program(None, Some(custom_confirm), check_if_executed_from_PATH) {
         eprintln!("Error: {}", e);
     }
 }

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -35,7 +35,7 @@ fn main() {
     };
 
     #[allow(non_snake_case)]
-    let check_if_executed_from_PATH = false; // Only ask for update when called from PATH
+    let check_if_executed_from_PATH = true; // Only ask for update when called from PATH
 
     if let Err(e) = relaunch_program(None, Some(custom_confirm), check_if_executed_from_PATH) {
         eprintln!("Error: {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,15 +118,15 @@ pub fn is_executed_from_path() -> bool {
     false // Executed from a full or relative path
 }
 
-/// A builder for configuring and launching a program.
+/// A builder for configuring an update query.
 ///
 /// The `RSpawn` allows users to configure various options such as
-/// the crate name, active features, user confirmation logic, and whether
-/// the program should be checked for execution from the PATH before launching.
+/// active features, user confirmation logic, and whether the program
+/// should be checked for execution from the PATH before launching.
 ///
 /// This builder pattern ensures that all configuration options are provided
 /// before launching the program. Once the builder is fully configured,
-/// the `relaunch_program` function can be called to actually execute the program.
+/// the `relaunch_program` function can be called to actually start the update query.
 ///
 /// # Example
 /// ```
@@ -217,10 +217,11 @@ where
         self
     }
 
-    /// Executes the program with the configured options.
+    /// Run update query with the configured options.
     ///
-    /// This method launches the program, checking for the active features, user
-    /// confirmation, and whether the program should be executed from the PATH.
+    /// This method queries crates.io for latest version and installs it with
+    /// cargo after checking for the active features, user confirmation,
+    /// and whether the program should be executed from the PATH.
     ///
     /// # Example
     /// ```
@@ -239,7 +240,7 @@ where
     ///
     /// # Returns
     /// * `Result<(), SomeError>` - A `Result` indicating whether the program was
-    ///   successfully launched or if an error occurred.
+    ///   successfully updated or if an error occurred.
     pub fn relaunch_program(self) -> Result<()> {
 
         let active_features = self.active_features.unwrap_or_default();
@@ -259,6 +260,29 @@ where
 // Type alias for the user-defined confirmation function
 pub type UserInputConfirmFn = Box<dyn FnMut(&str) -> bool>;
 
+/// Run update query with the configured options.
+///
+/// This method queries crates.io for latest version and installs it with
+/// cargo after checking for the active features, user confirmation,
+/// and whether the program should be executed from the PATH.
+///
+/// # Example
+/// ```
+/// let active_features = vec!["feature1".to_string(), "feature2".to_string()];
+/// let user_confirm = |version: &str| {
+///     println!("A new version {} is available. Would you like to install it? (yes/n): ", version);
+///     let mut response = String::new();
+///     io::stdin().read_line(&mut response).unwrap();
+///     response.trim().to_lowercase() == "yes"
+/// };
+/// let check_if_executed_from_PATH = false;
+/// let res = relaunch_program(Some(active_features), Some(user_confirm),
+/// check_if_executed_from_PATH);
+/// ```
+///
+/// # Returns
+/// * `Result<(), SomeError>` - A `Result` indicating whether the program was
+///   successfully updated or if an error occurred.
 pub fn relaunch_program<F>(
     active_features: Option<Vec<String>>,
     user_confirm: Option<F>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ use anyhow::{Result, Context}; // For better error handling
 use uuid::Uuid; // For generating unique filenames
 use log::{info, debug, error};
 
+/// Current rspawn version.
 pub const RSPAWN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // Function to generate a unique lock file path with a UUID
@@ -256,9 +257,6 @@ where
         relaunch_program(Some(active_features), Some(confirm_fn), check_if_executed_from_PATH)
     }
 }
-
-// Type alias for the user-defined confirmation function
-pub type UserInputConfirmFn = Box<dyn FnMut(&str) -> bool>;
 
 /// Run update query with the configured options.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 use anyhow::{Result, Context}; // For better error handling
 use uuid::Uuid; // For generating unique filenames
+pub const RSPAWN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // Function to generate a unique lock file path with a UUID
 fn generate_lock_file_path() -> PathBuf {
@@ -48,6 +49,7 @@ fn create_lock_file(lock_file_path: &Path) -> io::Result<()> {
 
 fn get_latest_version_from_crates_io(crate_name: &str) -> Result<String> {
     let url = format!("https://crates.io/api/v1/crates/{}/versions", crate_name);
+    let user_agent = format!("rspawn/{RSPAWN_VERSION} (https://github.com/jgabaut/rspawn");
 
     //eprintln!("Fetching latest version from: {}", url);
 
@@ -55,7 +57,7 @@ fn get_latest_version_from_crates_io(crate_name: &str) -> Result<String> {
     let client = reqwest::blocking::Client::new();
     let response = client
         .get(&url)
-        .header("User-Agent", "rspawn/0.1.0 (https://github.com/jgabaut/rspawn)")
+        .header("User-Agent", user_agent)
         .send()
         .context("Failed to fetch from crates.io")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub fn is_executed_from_path() -> bool {
 
 /// A builder for configuring and launching a program.
 ///
-/// The `RSpawnBuilder` allows users to configure various options such as
+/// The `RSpawn` allows users to configure various options such as
 /// the crate name, active features, user confirmation logic, and whether
 /// the program should be checked for execution from the PATH before launching.
 ///
@@ -130,7 +130,7 @@ pub fn is_executed_from_path() -> bool {
 ///
 /// # Example
 /// ```
-/// let builder = RSpawnBuilder::new("my_crate")
+/// let builder = RSpawn::new("my_crate")
 ///     .active_features(vec!["feature1".to_string(), "feature2".to_string()])
 ///     .user_confirm(Some(|version| {
 ///         println!("A new version {} is available. Would you like to install it? (y/n): ", version);
@@ -141,7 +141,7 @@ pub fn is_executed_from_path() -> bool {
 ///     .relaunch_program();
 /// ```
 #[allow(non_snake_case)]
-pub struct RSpawnBuilder<F>
+pub struct RSpawn<F>
 where
     F: FnMut(&str) -> bool + 'static,
 {
@@ -151,13 +151,13 @@ where
     check_if_executed_from_PATH: Option<bool>,
 }
 
-impl<F> RSpawnBuilder<F>
+impl<F> RSpawn<F>
 where
     F: FnMut(&str) -> bool + 'static,
 {
     // Create a new builder with default values
     pub fn new() -> Self {
-        RSpawnBuilder {
+        RSpawn {
             crate_name: None,
             active_features: None,
             user_confirm: None,
@@ -189,7 +189,7 @@ where
     ///
     /// # Example
     /// ```
-    /// let builder = RSpawnBuilder::new("my_crate")
+    /// let builder = RSpawn::new("my_crate")
     ///     .features(vec!["feature1".to_string(), "feature2".to_string()]);
     /// ```
     pub fn active_features(mut self, active_features: Vec<String>) -> Self {
@@ -209,7 +209,7 @@ where
     ///
     /// # Example
     /// ```
-    /// let builder = RSpawnBuilder::new("my_crate")
+    /// let builder = RSpawn::new("my_crate")
     ///     .user_confirm(Some(|version| {
     ///         println!("A new version {} is available. Would you like to install it? (y/n): ", version);
     ///         let mut response = String::new();
@@ -236,7 +236,7 @@ where
     ///
     /// # Example
     /// ```
-    /// let builder = RSpawnBuilder::new("my_crate")
+    /// let builder = RSpawn::new("my_crate")
     ///     .active_features(vec!["feature1".to_string(), "feature2".to_string()])
     ///     .user_confirm(Some(|version| {
     ///         println!("A new version {} is available. Would you like to install it? (y/n): ", version);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ fn generate_lock_file_path() -> PathBuf {
 }
 
 // Struct to handle lock file cleanup when the program exits
-pub struct LockFileGuard {
+struct LockFileGuard {
     lock_file_path: PathBuf,
 }
 


### PR DESCRIPTION
- Added `RSpawn`
  - Aimed at making user configuration easier
- Uses the current `rspawn` version for the user agent
- Declare crate as `lib`, move `main.rs` to `./examples/usage.rs`
- Added some docs
- Exclude `./github/**`, `CODEOWNERS` from `package` in `Cargo.toml`
- Drop `crate_name` argument, limiting users from setting an arbitrary crate name
- Drop `UserInputConfirmFn`